### PR TITLE
Added modifier: isNotOwner

### DIFF
--- a/contracts/NftMarketplace.sol
+++ b/contracts/NftMarketplace.sol
@@ -16,6 +16,9 @@ error NotOwner();
 error NotApprovedForMarketplace();
 error PriceMustBeAboveZero();
 
+// Error thrown for isNotOwner modifier
+// error IsNotOwner()
+
 contract NftMarketplace is ReentrancyGuard {
     struct Listing {
         uint256 price;
@@ -78,6 +81,22 @@ contract NftMarketplace is ReentrancyGuard {
         _;
     }
 
+    // IsNotOwner Modifier - Nft Owner can't buy his/her NFT
+    // Modifies buyItem function
+    // Owner should only list, cancel listing or update listing
+    /* modifier isNotOwner(
+        address nftAddress,
+        uint256 tokenId,
+        address spender
+    ) {
+        IERC721 nft = IERC721(nftAddress);
+        address owner = nft.ownerOf(tokenId);
+        if (spender == owner) {
+            revert IsNotOwner();
+        }
+        _;
+    } */
+
     /////////////////////
     // Main Functions //
     /////////////////////
@@ -133,6 +152,7 @@ contract NftMarketplace is ReentrancyGuard {
         external
         payable
         isListed(nftAddress, tokenId)
+        // isNotOwner(nftAddress, tokenId, msg.sender)
         nonReentrant
     {
         // Challenge - How would you refactor this contract to take:


### PR DESCRIPTION
Just a minimal observation that might be necessary. I observed that "Address A" lists an NFT and "Address A" can also buy the same NFT

So, In this pull request, I added a modifier, `isNotOwner` which prevents the owner of the NFT from buying it. 