### PR TITLE
Removed unused requires from verify.js

### DIFF
--- a/utils/verify.js
+++ b/utils/verify.js
@@ -1,5 +1,4 @@
-const { run, network } = require("hardhat")
-const { networkConfig } = require("../helper-hardhat-config")
+const { run } = require("hardhat")
 
 const verify = async (contractAddress, args) => {
     console.log("Verifying contract...")


### PR DESCRIPTION
Removed unused requires from hardhat and helper-hardhat-config.