### PR TITLE
Refactor: remove unused argument

### DIFF
--- a/contracts/NftMarketplace.sol
+++ b/contracts/NftMarketplace.sol
@@ -111,7 +111,7 @@ contract NftMarketplace is ReentrancyGuard {
         uint256 price
     )
         external
-        notListed(nftAddress, tokenId, msg.sender)
+        notListed(nftAddress, tokenId)
         isOwner(nftAddress, tokenId, msg.sender)
     {
         if (price <= 0) {

--- a/contracts/NftMarketplace.sol
+++ b/contracts/NftMarketplace.sol
@@ -50,8 +50,7 @@ contract NftMarketplace is ReentrancyGuard {
 
     modifier notListed(
         address nftAddress,
-        uint256 tokenId,
-        address owner
+        uint256 tokenId
     ) {
         Listing memory listing = s_listings[nftAddress][tokenId];
         if (listing.price > 0) {


### PR DESCRIPTION
This PR removes the `address owner` argument from the `notListed` modifier since it's not used at all.